### PR TITLE
fix apostrophe for convert dataset

### DIFF
--- a/boudams/dataset/base.py
+++ b/boudams/dataset/base.py
@@ -16,7 +16,7 @@ def normalize_space(string: str) -> str:
 def untokenize(sentence: Iterable[str]) -> Tuple[str, str]:
     """ Transform a sequence of words into both a string without space (first
     element of the tuple) and a string with space (second element of the tuple)"""
-    return "".join([re.sub("['’]", "", s) for s in sentence]), " ".join(sentence)
+    return "".join(sentence), " ".join(sentence)
 
 
 def formatter(sequence: Iterable[str]):

--- a/boudams/dataset/base.py
+++ b/boudams/dataset/base.py
@@ -16,7 +16,7 @@ def normalize_space(string: str) -> str:
 def untokenize(sentence: Iterable[str]) -> Tuple[str, str]:
     """ Transform a sequence of words into both a string without space (first
     element of the tuple) and a string with space (second element of the tuple)"""
-    return "".join(sentence), " ".join(sentence)
+    return "".join([re.sub("['’]", "", s) for s in sentence]), " ".join(sentence)
 
 
 def formatter(sequence: Iterable[str]):

--- a/boudams/dataset/plaintext.py
+++ b/boudams/dataset/plaintext.py
@@ -9,15 +9,15 @@ from typing import Iterable, Union
 from boudams.dataset.base import write_sentence, _space
 
 
-_splitter = re.compile("(\W+)")
-
+#_splitter = re.compile("(\W+)")
+_splitter = re.compile("(\w+['’]?)")
 
 def convert(
         input_path: Union[Iterable[str], str], output_path: str,
         min_words: int = 2, max_words: int = 10,
         min_char_length: int = 7, max_char_length: int = 100,
         random_keep: float = 0.3, max_kept: int = 1,
-        noise_char: str = ".", noise_char_random: float = 0.2, max_noise_char: int = 2,
+        noise_char: str = ".", noise_char_random: float = 0.2, max_noise_char: int = 2
         **kwargs
 ):
     """ Build sequence to train data over using TSV or TAB files where either the first
@@ -110,6 +110,7 @@ if __name__ == "__main__":
 
     inp = "/home/thibault/dev/boudams/test_data/bfmmss/txt/*.txt"
     output = "/home/thibault/dev/boudams/test_data/bfmmss/"
+
     max_char_length = 200
 
     convert(inp, output, max_char_length=200)

--- a/boudams/dataset/plaintext.py
+++ b/boudams/dataset/plaintext.py
@@ -17,7 +17,7 @@ def convert(
         min_words: int = 2, max_words: int = 10,
         min_char_length: int = 7, max_char_length: int = 100,
         random_keep: float = 0.3, max_kept: int = 1,
-        noise_char: str = ".", noise_char_random: float = 0.2, max_noise_char: int = 2
+        noise_char: str = ".", noise_char_random: float = 0.2, max_noise_char: int = 2,
         **kwargs
 ):
     """ Build sequence to train data over using TSV or TAB files where either the first

--- a/boudams/dataset/plaintext.py
+++ b/boudams/dataset/plaintext.py
@@ -9,8 +9,9 @@ from typing import Iterable, Union
 from boudams.dataset.base import write_sentence, _space
 
 
-#_splitter = re.compile("(\W+)")
-_splitter = re.compile("(\w+['’]?)")
+_splitter = re.compile("(\W+)")
+_apos = re.compile("['’]")
+
 
 def convert(
         input_path: Union[Iterable[str], str], output_path: str,
@@ -58,7 +59,7 @@ def convert(
                 sequence = []
                 next_sequence = random.randint(min_words, max_words)
 
-                content = input_fio.read()
+                content = _apos.sub(" ", input_fio.read())
 
                 for word in _splitter.split(content):
                     word = _space.sub("", word)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ leven==1.0.4
 click>=7.0,<=8.0
 regex==2019.5.25
 mufidecode
+matplotlib
+sklearn
+numpy


### PR DESCRIPTION
Déjà une première chose (simple): lors de la création des fichiers d'entraînement, résoudre la question des apostrophes. Nouveau résultat de la fonction `convert`:

````tsv
SainzTiebauzfunezenleveschédeTroies;	Sainz Tiebauz fu nez en l' evesché de Troies ;
;sesperesotnonErnous	; ses peres ot non Ernous
etsamere	et sa mere
````

La partie vraiment délicate concerne, j'imagine, l'encoder et le masque… Je vais essayer d'y jetter un œil, ça m'intéresse de voir un peu plus dans Boudams.
